### PR TITLE
Skeleton of bazaar.server Implementation for Graph Rendering 

### DIFF
--- a/bazaarci/server/__init__.py
+++ b/bazaarci/server/__init__.py
@@ -1,0 +1,11 @@
+
+from flask import Flask
+
+def create_app(config=None):
+    app = Flask(__name__, template_folder='assets/html', static_folder='assets')
+
+    from .views import graph
+    app.register_blueprint(graph.bp)
+
+    return app
+

--- a/bazaarci/server/__main__.py
+++ b/bazaarci/server/__main__.py
@@ -1,0 +1,8 @@
+
+from . import create_app
+
+if __name__ == "__main__":
+    app = create_app(config="Production/LocalRun/etc")
+    app.run()
+
+

--- a/bazaarci/server/assets/css/.gitignore
+++ b/bazaarci/server/assets/css/.gitignore
@@ -1,0 +1,5 @@
+# Ignore all files that aren't css
+*
+!.gitignore
+!*.css
+!*/

--- a/bazaarci/server/assets/html/.gitignore
+++ b/bazaarci/server/assets/html/.gitignore
@@ -1,0 +1,5 @@
+# Ignore all files that aren't css
+*
+!.gitignore
+!*.html
+!*/

--- a/bazaarci/server/assets/html/graph.html
+++ b/bazaarci/server/assets/html/graph.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <!--link rel="stylesheet" href="{{ ASSET_URL }}"-->
+        <title>BazaarCI</title>
+    </head>
+    <body>
+        <!-- Banner Section -->
+        <div>
+            <h2>BazaarCI</h2>
+        </div>
+
+        <!-- Display Section -->
+        <div id="graph" style="text-align: center;"></div>
+
+    </body>
+
+    <!--script type="text/javascript" src="{{ ASSET_URL }}"></script-->
+    <script src="//d3js.org/d3.v4.min.js"></script>
+    <script src="https://unpkg.com/viz.js@1.8.0/viz.js" type="javascript/worker"></script>
+    <script src="https://unpkg.com/d3-graphviz@1.3.1/build/d3-graphviz.min.js"></script>
+    <script src="{{ url_for('static', filename="js/gvd3demo.js")}}"></script>
+</html>

--- a/bazaarci/server/assets/js/.gitignore
+++ b/bazaarci/server/assets/js/.gitignore
@@ -1,0 +1,5 @@
+# Ignore all files that aren't css
+*
+!.gitignore
+!*.js
+!*/

--- a/bazaarci/server/assets/js/gvd3demo.js
+++ b/bazaarci/server/assets/js/gvd3demo.js
@@ -1,0 +1,122 @@
+
+var dotIndex = 0;
+var graphviz = d3.select("#graph").graphviz()
+    .transition(function () {
+        return d3.transition("main")
+            .ease(d3.easeLinear)
+            .delay(500)
+            .duration(1500);
+    })
+    .logEvents(true)
+    .on("initEnd", render);
+
+function render() {
+    var dotLines = dots[dotIndex];
+    var dot = dotLines.join('');
+    graphviz
+        .renderDot(dot)
+        .on("end", function () {
+            dotIndex = (dotIndex + 1) % dots.length;
+            render();
+        });
+}
+
+var dots = [
+    [
+        'digraph  {',
+        '    node [style="filled"]',
+        '    a [fillcolor="#d62728"]',
+        '    b [fillcolor="#1f77b4"]',
+        '    a -> b',
+        '}'
+    ],
+    [
+        'digraph  {',
+        '    node [style="filled"]',
+        '    a [fillcolor="#d62728"]',
+        '    c [fillcolor="#2ca02c"]',
+        '    b [fillcolor="#1f77b4"]',
+        '    a -> b',
+        '    a -> c',
+        '}'
+    ],
+    [
+        'digraph  {',
+        '    node [style="filled"]',
+        '    a [fillcolor="#d62728"]',
+        '    b [fillcolor="#1f77b4"]',
+        '    c [fillcolor="#2ca02c"]',
+        '    a -> b',
+        '    a -> c',
+        '}'
+    ],
+    [
+        'digraph  {',
+        '    node [style="filled"]',
+        '    a [fillcolor="#d62728", shape="box"]',
+        '    b [fillcolor="#1f77b4", shape="parallelogram"]',
+        '    c [fillcolor="#2ca02c", shape="pentagon"]',
+        '    a -> b',
+        '    a -> c',
+        '    b -> c',
+        '}'
+    ],
+    [
+        'digraph  {',
+        '    node [style="filled"]',
+        '    a [fillcolor="yellow", shape="star"]',
+        '    b [fillcolor="yellow", shape="star"]',
+        '    c [fillcolor="yellow", shape="star"]',
+        '    a -> b',
+        '    a -> c',
+        '    b -> c',
+        '}'
+    ],
+    [
+        'digraph  {',
+        '    node [style="filled"]',
+        '    a [fillcolor="#d62728", shape="triangle"]',
+        '    b [fillcolor="#1f77b4", shape="diamond"]',
+        '    c [fillcolor="#2ca02c", shape="trapezium"]',
+        '    a -> b',
+        '    a -> c',
+        '    b -> c',
+        '}'
+    ],
+    [
+        'digraph  {',
+        '    node [style="filled"]',
+        '    a [fillcolor="#d62728", shape="box"]',
+        '    b [fillcolor="#1f77b4", shape="parallelogram"]',
+        '    c [fillcolor="#2ca02c", shape="pentagon"]',
+        '    a -> b',
+        '    a -> c',
+        '    b -> c',
+        '}'
+    ],
+    [
+        'digraph  {',
+        '    node [style="filled"]',
+        '    a [fillcolor="#d62728"]',
+        '    b [fillcolor="#1f77b4"]',
+        '    c [fillcolor="#2ca02c"]',
+        '    a -> b',
+        '    a -> c',
+        '    c -> b',
+        '}'
+    ],
+    [
+        'digraph  {',
+        '    node [style="filled"]',
+        '    b [fillcolor="#1f77b4"]',
+        '    c [fillcolor="#2ca02c"]',
+        '    c -> b',
+        '}'
+    ],
+    [
+        'digraph  {',
+        '    node [style="filled"]',
+        '    b [fillcolor="#1f77b4"]',
+        '}'
+    ],
+];

--- a/bazaarci/server/views/graph.py
+++ b/bazaarci/server/views/graph.py
@@ -1,0 +1,10 @@
+
+from flask import Blueprint, render_template, request
+
+bp = Blueprint('graph', __name__)
+
+@bp.route('/')
+def index():
+    return render_template('graph.html')
+
+

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,6 @@ setup(
     packages=[
         'bazaarci',
         'bazaarci.runner',
+        'bazaarci.server',
     ],
 )


### PR DESCRIPTION
Sketched in some code using Flask as the WSGI API, and hooked up the d3-graphviz demo into the frame. Needs some more embelishment on the API, callbacks, usage, and controllers. 

To run the demo:
```
python3 -m bazaarci.server 
```