### PR TITLE
Proposing method for grabbing returned CompletedProcess object for SubprocessStep

### DIFF
--- a/bazaarci/runner/subprocessstep.py
+++ b/bazaarci/runner/subprocessstep.py
@@ -7,8 +7,12 @@ from bazaarci.runner import Step
 
 class SubprocessStep(Step):
     def __init__(self, name, graph: Optional["Graph"], *sp_args, **sp_kwargs):
+        self.returned = None
         super().__init__(
             name,
             graph,
-            target=partial(subprocess.run, *sp_args, **sp_kwargs),
+            target=self.run_grabbing_returned(*sp_args, **sp_kwargs),
         )
+
+    def run_grabbing_returned(self, *sp_args, **sp_kwargs):
+        self.returned = subprocess.run(*sp_args, **sp_kwargs)


### PR DESCRIPTION
subprocess.run() returns a [CompleteProcess](https://docs.python.org/3/library/subprocess.html#subprocess.CompletedProcess) object. I think it's gonna be a very common requirement to want to get at the return code after a SubprocessStep completes.

What do y'all think of something like this for storing that object as a member of SubprocessStep? Am I overlooking a more elegant way of getting at the subprocess's return code?