### PR TITLE
Implementation of BEP2 Proposal 2

### DIFF
--- a/bazaarci/runner/node.py
+++ b/bazaarci/runner/node.py
@@ -1,4 +1,4 @@
-from typing import Optional, Set, Union
+from typing import Any, Optional, Set, Union
 
 
 class Node:
@@ -27,11 +27,4 @@ class Node:
         """
         raise NotImplementedError(
             "Class `{}` has not implemented a `start` method!".format(self.__class__.__name__)
-        )
-
-    def run(self) -> None:
-        """ Code that will be executed in the background thread.
-        """
-        raise NotImplementedError(
-            "Class `{}` has not implemented a `run` method!".format(self.__class__.__name__)
         )

--- a/bazaarci/runner/step.py
+++ b/bazaarci/runner/step.py
@@ -1,4 +1,7 @@
-from functools import reduce
+""" Step
+Definition of the Step class and run behavior decorator functions
+"""
+from functools import reduce, wraps
 from threading import Event, Thread
 from typing import Callable, Optional
 
@@ -35,15 +38,10 @@ class Step(Node):
         self.thread = Thread(target=self.run)
         self.thread.start()
 
-    def run(self):
-        [product.wait() for product in self.consumes()]
-        # Once all inputs are available, check that there are unset outputs.
-        # If all output products have already been set, then this step is
-        # not required to run.
-        if reduce(lambda x, y: x and y.wait(0), self.produces(), True):
-            if self.target is not None:
-                self.output = self.target()
-            [product.set() for product in self.produces()]
+    def _run(self):
+        if self.target and callable(self.target):
+            self.output = self.target()
+        [product.set() for product in self.produces()]
 
     def wait(self):
         if self.thread and self.thread.is_alive():
@@ -54,3 +52,42 @@ class Step(Node):
 
     def __repr__(self):
         return "{}({})".format(self.__class__.__name__, self.name)
+
+
+def set_run_behavior(class_or_instance, *args):
+    """ Build the run function from _run and the
+    incoming list of behaviorals
+    """
+    run_function = class_or_instance._run
+    for wrapper in reversed(args):
+        run_function = wrapper(run_function)
+    setattr(class_or_instance, "run", run_function)
+
+
+def wait_for_producers(func):
+    """ Waits on all `Product`s in `self.consumes` before
+    calling the function.
+    """
+    @wraps(func)
+    def wrapped(self):
+        [product.wait() for product in self.consumes()]
+        func(self)
+    return wrapped
+
+
+def skip_if_redundant(func):
+    """ Calls the function only if any output `Product`s
+    have not been set yet.
+    """
+    @wraps(func)
+    def wrapped(self):
+        # If there are output products and they have all already been set,
+        # then this step is not required to run.
+        all_set = reduce(lambda x, y: x and y.wait(0), self.produces(), True)
+        if len(self.produces()) == 0 or not all_set:
+            func(self)
+    return wrapped
+
+
+# By default, Step should wait for producers
+set_run_behavior(Step, wait_for_producers)

--- a/tests/test_Step.py
+++ b/tests/test_Step.py
@@ -32,7 +32,16 @@ class TestStep(TestCase):
         mock_Thread.assert_called_once_with(target=s.run)
 
     def test_run(self):
-        mock_target = MagicMock()
-        s = Step("test", target=mock_target)
-        s.run()
-        mock_target.assert_called_once_with()
+        with self.subTest("Productive Step"):
+            mock_target = MagicMock()
+            s = Step("test", target=mock_target)
+            s.run()
+            mock_target.assert_called_once_with()
+        with self.subTest("Non-Productive Step"):
+            mock_target = MagicMock()
+            s = Step("test", target=mock_target)
+            mock_product = MagicMock()
+            mock_product.wait.return_value = False
+            s.produces(mock_product)
+            s.run()
+            mock_target.assert_not_called()

--- a/tests/test_Step.py
+++ b/tests/test_Step.py
@@ -31,17 +31,8 @@ class TestStep(TestCase):
         self.assertIsNotNone(s.thread)
         mock_Thread.assert_called_once_with(target=s.run)
 
-    def test_run(self):
-        with self.subTest("Productive Step"):
-            mock_target = MagicMock()
-            s = Step("test", target=mock_target)
-            s.run()
-            mock_target.assert_called_once_with()
-        with self.subTest("Non-Productive Step"):
-            mock_target = MagicMock()
-            s = Step("test", target=mock_target)
-            mock_product = MagicMock()
-            mock_product.wait.return_value = False
-            s.produces(mock_product)
-            s.run()
-            mock_target.assert_not_called()
+    def test__run(self):
+        mock_target = MagicMock()
+        s = Step("test", target=mock_target)
+        s._run()
+        mock_target.assert_called_once_with()

--- a/tests/test_step_run_behavior.py
+++ b/tests/test_step_run_behavior.py
@@ -1,0 +1,50 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+from bazaarci.runner.step import set_run_behavior, wait_for_producers, skip_if_redundant
+
+
+class TestStepRunBehavior(TestCase):
+    def test_set_run_behavior(self):
+        mock_Step = MagicMock()
+        mock_Decorator1 = MagicMock()
+        mock_Decorator2 = MagicMock()
+        set_run_behavior(mock_Step, mock_Decorator1, mock_Decorator2)
+        mock_Decorator2.assert_called_once_with(mock_Step._run)
+        mock_Decorator1.assert_called_once_with(mock_Decorator2.return_value)
+
+    def test_wait_for_producers(self):
+        mock_Step = MagicMock()
+        mock_run = MagicMock()
+        mock_Step.consumes.return_value = [MagicMock()]
+        wrapped_run = wait_for_producers(mock_run)
+        wrapped_run(mock_Step)
+        mock_Step.consumes.assert_called_once_with()
+        mock_Step.consumes.return_value[0].wait.assert_called_once_with()
+        mock_run.assert_called_once_with(mock_Step)
+
+    def test_skip_if_redundant(self):
+        with self.subTest("No output Products"):
+            mock_Step = MagicMock()
+            mock_run = MagicMock()
+            mock_Step.produces.return_value = []
+            wrapped_run = skip_if_redundant(mock_run)
+            wrapped_run(mock_Step)
+            mock_run.assert_called_once_with(mock_Step)
+        with self.subTest("Unset output Product"):
+            # The output Product is not set, run
+            mock_Step = MagicMock()
+            mock_run = MagicMock()
+            mock_Step.produces.return_value = [MagicMock()]
+            mock_Step.produces.return_value[0].wait.return_value = False
+            wrapped_run = skip_if_redundant(mock_run)
+            wrapped_run(mock_Step)
+            mock_run.assert_called_once_with(mock_Step)
+        with self.subTest("Set output Product"):
+            # The output Product is set, skip run
+            mock_Step = MagicMock()
+            mock_run = MagicMock()
+            mock_Step.produces.return_value = [MagicMock()]
+            mock_Step.produces.return_value[0].wait.return_value = True
+            wrapped_run = skip_if_redundant(mock_run)
+            wrapped_run(mock_Step)
+            mock_run.assert_not_called()

--- a/tests/test_step_run_behavior.py
+++ b/tests/test_step_run_behavior.py
@@ -24,6 +24,7 @@ class TestStepRunBehavior(TestCase):
 
     def test_skip_if_redundant(self):
         with self.subTest("No output Products"):
+            # There are no outputs, always run
             mock_Step = MagicMock()
             mock_run = MagicMock()
             mock_Step.produces.return_value = []


### PR DESCRIPTION
If all `Product`s produced by a `Step` have already been set, this will not actually call the target function.  In the case of a `Step` that produces no `Product`s, the `Step` always calls it's target.